### PR TITLE
lint: comando "pre-commit": "lint-staged"

### DIFF
--- a/linter.md
+++ b/linter.md
@@ -64,7 +64,7 @@ vue add @vue/cli-plugin-eslint
 npm run lint
 ```
 
-- Además se habilitó el siguiente git hook con la opción de formatear y ejecutar el `linter` en cada `commit` en el archivo `packaje.json`:
+- Además, se habilitó el siguiente git hook con la opción de formatear y ejecutar el `linter` en cada `commit` en el archivo `packaje.json`:
 
 ```json
   "gitHooks": {

--- a/linter.md
+++ b/linter.md
@@ -1,14 +1,14 @@
 # Linter de código
 
-Permite definir ciertas reglas para que todos los desarrolladores de ese proyecto las cumplan y las apliquen en el código.
+Permite definir ciertas reglas para que todos los desarrolladores de este proyecto las cumplan y las apliquen en el código.
 
-El siguiente comando sirve para dar formato y correcciones de las reglas definidas par el código:
+El siguiente comando sirve para dar formato y correcciones de las reglas definidas para el código:
 
 ```sh
 npm run format-lint
 ```
 
-> Es posible automatizar la correción de errores en _Visual Studio Code_, al guardar archivos, con la configuración definida en la carpeta `.vscode` en la raíz del proyecto.
+> Es posible automatizar la corrección de errores en _Visual Studio Code_, al guardar archivos, con la configuración definida en la carpeta `.vscode` en la raíz del proyecto.
 
 ## EditorConfig
 
@@ -19,6 +19,28 @@ Visita [editorconfig.org](https://editorconfig.org) para más información
 ### Configuración EditorConfig
 
 - Se agregó el archivo [.editorconfig](./.editorconfig)
+
+## Prettier
+
+Es un formateador de código que admite muchos lenguajes y se integra con la mayoría de los editores.
+
+Permite configurarse para formatear al guardar cambios ahorrando tiempo y energía.
+
+### Configuración Prettier
+
+- Se instaló cómo dependencia de desarrollo con:
+
+```sh
+npm install --save-dev --save-exact prettier
+```
+
+- Se agregó el archivo [.prettierrc.js](./.prettierrc.js).
+- Para habilitar el formateo al guardar en VS Code, se añadío la configuración en [.vscode/settings.json](./.vscode/settings.json).
+- Se agregó el script `prettier . --write` en el package.json para hacer la magia (en caso de que no funcione al guardar) ejecutando:
+
+```sh
+npm run format
+```
 
 ## ESlint
 
@@ -36,26 +58,16 @@ Visita [eslint.org](https://eslint.org) para más información
 vue add @vue/cli-plugin-eslint
 ```
 
-- Además se habilitaron la opción de formatear al guardar y ejecutar el `linter` en cada `commit`.
-
-## Prettier
-
-Es un formateador de código que admite muchos lenguajes y se integra con la mayoría de los editores.
-
-Permite configurarse para formatear al guardar cambios ahorrando tiempo y energía
-
-### Configuración Prettier
-
-- Se instaló cómo dependencia de desarrollo con:
+- El comando preparado para ejecutar el linter en este proyecto con `vue-cli-service lint` es:
 
 ```sh
-npm install --save-dev --save-exact prettier
+npm run lint
 ```
 
-- Se agregó el archivo [.prettierrc.js](./.prettierrc.js).
-- Para habilitar el formateo al guardar en VS Code, se añadío la configuración en [.vscode/settings.json](./.vscode/settings.json).
-- Se agregó el script `prettier . --write` en el package.json para hacer la magia (en caso de que no funcione al guardar) ejecutando:
+- Además se habilitó el siguiente git hook con la opción de formatear y ejecutar el `linter` en cada `commit` en el archivo `packaje.json`:
 
-```sh
-npm run format
+```json
+  "gitHooks": {
+    "pre-commit": "lint-staged"
+  },
 ```

--- a/package.json
+++ b/package.json
@@ -40,5 +40,12 @@
     "vue-template-compiler": "^2.7.14",
     "vuepress": "^1.9.8",
     "vuepress-html-webpack-plugin": "^3.2.0"
+  },
+  "gitHooks": {
+    "pre-commit": "lint-staged"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/salsa-community/sisdai-componentes"
   }
 }


### PR DESCRIPTION
Se agregó el comando y la documentación de Lint staged, el cual permite que ejecutar el Linter en cada comit (guardando cambios en el staged mientras se ejecutan las reglas de eslint).

![image](https://user-images.githubusercontent.com/47924469/225346217-8cf8d253-7f35-4c06-830c-d7cebe7d3627.png)
