### PR TITLE
Bugfix/estructura vuepress

### DIFF
--- a/docs/.vuepress/components/nav/NavegacionPrincipal.vue
+++ b/docs/.vuepress/components/nav/NavegacionPrincipal.vue
@@ -46,16 +46,9 @@
             >
           </li>
           <li>
-            <RouterLink
-              class="nav-hipervinculo"
-              to="/ejemplos/"
-              >Ejemplos</RouterLink
-            >
-          </li>
-          <li>
             <a
               class="nav-hipervinculo"
-              href="https://github.com/salsa-community/"
+              href="https://github.com/salsa-community/sisdai-componentes"
               >GitHub</a
             >
           </li>


### PR DESCRIPTION
- Se eliminó la sección de ejemplos
- Se cambió la url del repo de github

https://project.crip.conacyt.mx/project/macrocelula/task/1552

<img width="322" alt="Screen Shot 2023-03-22 at 17 43 56" src="https://user-images.githubusercontent.com/18044759/227063220-f2472f78-371d-4c8b-9787-30ceb24180e9.png">
