### PR TITLE
fix de submenú en móvil y desenfocable

### DIFF
--- a/docs/.vuepress/components/navegacion-principal/contenido-personalizado.vue
+++ b/docs/.vuepress/components/navegacion-principal/contenido-personalizado.vue
@@ -1,11 +1,15 @@
 <script setup>
 import { ref } from 'vue'
 
-const submenuEstaAbierto = ref(false)
+const sisdai_nav_ppal = ref('')
+
+function alternarSubmenu() {
+  sisdai_nav_ppal.value._setupState.alternarSubmenu()
+}
 </script>
 <template>
   <div class="contenedor">
-    <SisdaiNavegacionPrincipal>
+    <SisdaiNavegacionPrincipal ref="sisdai_nav_ppal">
       <!--Definiendo el logo del sitio-->
       <template #identidad>
         <a
@@ -34,18 +38,15 @@ const submenuEstaAbierto = ref(false)
         <li class="nav-contenedor-submenu">
           <button
             class="nav-boton-submenu"
-            @click="submenuEstaAbierto = !submenuEstaAbierto"
+            @click="alternarSubmenu"
           >
             Submenu
           </button>
-          <ul
-            class="nav-submenu"
-            :class="{ abierto: submenuEstaAbierto }"
-          >
+          <ul class="nav-submenu">
             <li>
               <button
                 class="nav-boton-regresar"
-                @click="submenuEstaAbierto = !submenuEstaAbierto"
+                @click="alternarSubmenu"
               >
                 Submenu
               </button>

--- a/docs/documentacion/navegacion-principal/index.md
+++ b/docs/documentacion/navegacion-principal/index.md
@@ -115,6 +115,6 @@ Agregando contenido personalizado
 
 Para que la subnavegación en versión la móvil se abra y cierre, se deberá agregar la lógica que alterne la clase css dinámica `abierto` del elemento de lista `ul` con el selector `nav-submenu`.
 
-Dicha alternancia se puede lograr mediante un evento de clic en los elementos `button` con los selectores `nav-boton-submenu` y `nav-boton-regresar`.
+Dicha alternancia se puede lograr mediante un evento de clic en los elementos `button` con los selectores `nav-boton-submenu` y `nav-boton-regresar` para llamar a la función `alternarSubmenu` del `_setupState` de referencia o instancia del componente.
 
 </section>

--- a/docs/documentacion/navegacion-principal/index.md
+++ b/docs/documentacion/navegacion-principal/index.md
@@ -113,8 +113,8 @@ Agregando contenido personalizado
 
 <utils-ejemplo-doc ruta="navegacion-principal/contenido-personalizado.vue"/>
 
-Para que la subnavegación en versión la móvil se abra y cierre, se deberá agregar la lógica que alterne la clase css dinámica `abierto` del elemento de lista `ul` con el selector `nav-submenu`.
+Para que la subnavegación en la móvil versión se abra y cierre, se deberá agregar la lógica que alterne la clase dinámica css `abierto` del elemento de lista `ul` con el selector `nav-submenu`.
 
-Dicha alternancia se puede lograr mediante un evento de clic en los elementos `button` con los selectores `nav-boton-submenu` y `nav-boton-regresar` para llamar a la función `alternarSubmenu` del `_setupState` de referencia o instancia del componente.
+Dicha alternancia se puede lograr mediante un evento de clic en los elementos `button` con los selectores `nav-boton-submenu` y `nav-boton-regresar` para llamar a la función `alternarSubmenu` del `_setupState` de la referencia o instancia del componente.
 
 </section>

--- a/src/componentes/navegacion-principal/SisdaiNavegacionPrincipal.vue
+++ b/src/componentes/navegacion-principal/SisdaiNavegacionPrincipal.vue
@@ -15,8 +15,12 @@ defineProps({
 
 //Que el menu se pueda cerrar automaticamente al enfocar otra cosa
 const cuadroElementosMenu = ref(null)
-const { menuEstaAbierto, alternarMenu } =
-  useMenuDesenfocable(cuadroElementosMenu)
+const {
+  menuEstaAbierto,
+  alternarMenu,
+  // eslint-disable-next-line
+  alternarSubmenu,
+} = useMenuDesenfocable(cuadroElementosMenu)
 </script>
 
 <template>


### PR DESCRIPTION
- Submenú tenía otro bug en la versión móvil. Sucedía cuando abrías el submenú y luego le picabas al botón de cerrar de la navegación principal. La subnavegación se recorría y se abría el menú principal como en la foto:

![Screen Shot 2023-05-03 at 15 22 43](https://user-images.githubusercontent.com/18044759/236052859-a7908761-1769-4499-b08b-4c3241673eba.png)

Con pr se arregla ese bug y además se integran las variables necesarias en el composable useMenuDesenfocado para que también se cierre el submenu cuando la persona pique fuera de la navegación.

El único detalle que le veo es que tiene una línea comentada para desactivar el slint porque no encontré, de momento, otra forma de solucionar el error que me mandaba.