### PR TITLE
removiendo 'y' extra de nombre accesible en iconos de redes sociales …

### DIFF
--- a/src/componentes/pie-pagina-conahcyt/SisdaiPiePaginaConahcyt.vue
+++ b/src/componentes/pie-pagina-conahcyt/SisdaiPiePaginaConahcyt.vue
@@ -110,7 +110,7 @@
               class="icono-social-youtube icono-3"
               aria-hidden="true"
             ></span>
-            <span class="a11y-solo-lectura">y yutub</span>
+            <span class="a11y-solo-lectura">yutub</span>
           </a>
         </p>
       </nav>

--- a/src/componentes/pie-pagina-gob-mx/SisdaiPiePaginaGobMx.vue
+++ b/src/componentes/pie-pagina-gob-mx/SisdaiPiePaginaGobMx.vue
@@ -170,7 +170,7 @@
               class="icono-social-twitter icono-3"
               aria-hidden="true"
             ></span>
-            <span class="a11y-solo-lectura">y tuiter.</span>
+            <span class="a11y-solo-lectura">tuiter.</span>
           </a>
         </p>
       </nav>


### PR DESCRIPTION
- Se remueve la "y" de los nombres accesibles en los iconos de las redes sociales de los footers

https://project.crip.conacyt.mx/project/macrocelula/task/2650