### PR TITLE
Fix/semantica accesible

### DIFF
--- a/src/componentes/boton-flotante/SisdaiBotonFlotante.vue
+++ b/src/componentes/boton-flotante/SisdaiBotonFlotante.vue
@@ -16,7 +16,7 @@ const propiedades = {
 </script>
 
 <script setup>
-import { ref, toRefs } from 'vue'
+import { ref, toRefs, watch } from 'vue'
 
 const props = defineProps(propiedades)
 const { enlaces } = toRefs(props)
@@ -38,6 +38,25 @@ function alternarEstado() {
 }
 
 defineExpose({ alternarEstado })
+
+/**
+ * Si el botón está abierto, remueve el atributo tabIndex.
+ * Si está cerrado, agrega el atributo tabIndex en -1 para
+ * saltarse los enlaces con el teclado secuencial.
+ */
+watch(botonFlotanteEstaAbierto, () => {
+  if (botonFlotanteEstaAbierto.value) {
+    enlaces.value.forEach((element, idx) => {
+      document
+        .getElementById(`boton_flotante_enlace_${idx}`)
+        .removeAttribute('tabIndex')
+    })
+  } else {
+    enlaces.value.forEach((element, idx) => {
+      document.getElementById(`boton_flotante_enlace_${idx}`).tabIndex = '-1'
+    })
+  }
+})
 </script>
 
 <template>
@@ -67,6 +86,7 @@ defineExpose({ alternarEstado })
       <a
         v-for="({ enlace, clasesCss, icono, contenido }, idx) in enlaces"
         :key="`boton-flotante-enlace-${idx}`"
+        :id="`boton_flotante_enlace_${idx}`"
         :href="enlace"
         :class="`enlace p-x-1 borde-redondeado-0 ${
           clasesCss === undefined ? '' : clasesCss

--- a/src/componentes/boton-flotante/SisdaiBotonFlotante.vue
+++ b/src/componentes/boton-flotante/SisdaiBotonFlotante.vue
@@ -68,6 +68,7 @@ watch(botonFlotanteEstaAbierto, () => {
       :class="`boton-flotante-alternador borde-r-redondeado-20 borde-l-redondeado-${
         botonFlotanteEstaAbierto ? '' : '2'
       }0`"
+      :aria-expanded="botonFlotanteEstaAbierto ? 'true' : 'false'"
       @click="alternarEstado"
     >
       <span

--- a/src/componentes/colapsable-navegacion/SisdaiColapsableNavegacion.vue
+++ b/src/componentes/colapsable-navegacion/SisdaiColapsableNavegacion.vue
@@ -4,6 +4,7 @@
     class="colapsable-navegacion"
   >
     <button
+      :aria-expanded="esta_activo ? 'true' : 'false'"
       class="colapsable-boton-submenu"
       @click="esta_activo = !esta_activo"
     >

--- a/src/componentes/menu-accesibilidad/SisdaiMenuAccesibilidad.vue
+++ b/src/componentes/menu-accesibilidad/SisdaiMenuAccesibilidad.vue
@@ -138,7 +138,7 @@ const alturaMenuAbierto = computed(
     </button>
 
     <menu class="menu-accesibilidad">
-      <h6 class="titulo">Herramientas de accesibilidad</h6>
+      <p class="titulo">Herramientas de accesibilidad</p>
 
       <button
         class="opcion-accesibilidad"

--- a/src/componentes/menu-accesibilidad/SisdaiMenuAccesibilidad.vue
+++ b/src/componentes/menu-accesibilidad/SisdaiMenuAccesibilidad.vue
@@ -47,7 +47,7 @@ const eventos = {
 </script>
 
 <script setup>
-import { computed, ref, toRefs } from 'vue'
+import { computed, ref, toRefs, watch } from 'vue'
 import opcionesDefault from './opcionesDefault'
 
 const props = defineProps(propiedades)
@@ -111,6 +111,29 @@ function alternarEstado() {
 defineExpose({ alternarEstado })
 
 /**
+ * Si el menú está abierto, remueve el atributo tabIndex.
+ * Si está cerrado, agrega el atributo tabIndex en -1 para
+ * saltarse las opciones con el teclado secuencial.
+ */
+watch(menuAccesibilidadEstaAbierto, () => {
+  if (menuAccesibilidadEstaAbierto.value) {
+    opciones.value.forEach((element, idx) => {
+      document
+        .getElementById(`opcion_accesibilidad_${idx}`)
+        .removeAttribute('tabIndex')
+    })
+    document
+      .getElementById('opcion_accesibilidad_restablecer')
+      .removeAttribute('tabIndex')
+  } else {
+    opciones.value.forEach((element, idx) => {
+      document.getElementById(`opcion_accesibilidad_${idx}`).tabIndex = '-1'
+    })
+    document.getElementById('opcion_accesibilidad_restablecer').tabIndex = '-1'
+  }
+})
+
+/**
  * Altura en pixeles del menú abierto, se calcula dando 50 pixeles a cada opción sumando la
  * opción de restablecer y el titulo del menú.
  */
@@ -142,8 +165,10 @@ const alturaMenuAbierto = computed(
 
       <button
         class="opcion-accesibilidad"
+        tabindex="-1"
         v-for="(opcion, idx) in opciones"
         :key="`opcion-accesibilidad-${idx}`"
+        :id="`opcion_accesibilidad_${idx}`"
         @click="seleccionarOpcion(opcion)"
       >
         <span
@@ -156,6 +181,8 @@ const alturaMenuAbierto = computed(
 
       <button
         class="opcion-accesibilidad"
+        tabindex="-1"
+        id="opcion_accesibilidad_restablecer"
         @click="restablecer"
       >
         <span

--- a/src/componentes/menu-accesibilidad/SisdaiMenuAccesibilidad.vue
+++ b/src/componentes/menu-accesibilidad/SisdaiMenuAccesibilidad.vue
@@ -149,6 +149,7 @@ const alturaMenuAbierto = computed(
   >
     <button
       class="icono-boton-accesibilidad"
+      :aria-expanded="menuAccesibilidadEstaAbierto ? 'true' : 'false'"
       @click="alternarEstado"
     >
       <span

--- a/src/componentes/menu-lateral/SisdaiMenuLateral.vue
+++ b/src/componentes/menu-lateral/SisdaiMenuLateral.vue
@@ -8,7 +8,10 @@
       @click="menu_abierto = !menu_abierto"
       :class="{ abierto: menu_abierto }"
     >
-      <button class="boton-icono boton-menu">
+      <button
+        :aria-expanded="menu_abierto ? 'true' : 'false'"
+        class="boton-icono boton-menu"
+      >
         <span
           v-if="menu_abierto"
           class="icono-angulo-doble-izquierda"

--- a/src/componentes/navegacion-gob-mx/SisdaiNavegacionGobMx.vue
+++ b/src/componentes/navegacion-gob-mx/SisdaiNavegacionGobMx.vue
@@ -35,7 +35,6 @@
     >
       <div
         class="nav-menu-principal"
-        tabindex="0"
         ref="cuadroElementosMenu"
         @click="alternarMenu"
       >

--- a/src/componentes/navegacion-gob-mx/SisdaiNavegacionGobMx.vue
+++ b/src/componentes/navegacion-gob-mx/SisdaiNavegacionGobMx.vue
@@ -20,6 +20,7 @@
       </a>
       <button
         @click="alternarMenu"
+        :aria-expanded="menuEstaAbierto ? 'true' : 'false'"
         class="nav-boton-menu"
         :class="{ abierto: menuEstaAbierto }"
       >

--- a/src/componentes/navegacion-principal/SisdaiNavegacionPrincipal.vue
+++ b/src/componentes/navegacion-principal/SisdaiNavegacionPrincipal.vue
@@ -69,7 +69,6 @@ const {
     >
       <div
         class="nav-menu-principal"
-        tabindex="0"
         ref="cuadroElementosMenu"
         @click="alternarMenu"
       >

--- a/src/componentes/navegacion-principal/SisdaiNavegacionPrincipal.vue
+++ b/src/componentes/navegacion-principal/SisdaiNavegacionPrincipal.vue
@@ -47,6 +47,7 @@ const {
       </slot>
       <button
         @click="alternarMenu"
+        :aria-expanded="menuEstaAbierto ? 'true' : 'false'"
         class="nav-boton-menu"
         :class="{ abierto: menuEstaAbierto }"
       >


### PR DESCRIPTION
- Se cambia < h6 > por < p > en el título del menú de accesibilidad
- Se remueve el tabIndex de las barras de navegación principal y gobmx
- Se crea una condición para saltar con el teclado las opciones del menú de accesibilidad y el botón flotante cuando estos están cerrados
- Se agrega el atributo aria-expanded para avisar cuando los colapsables, menús y barras de navegación están abiertas o cerradas

https://project.crip.conacyt.mx/project/macrocelula/task/2703
https://project.crip.conacyt.mx/project/macrocelula/task/2710
https://project.crip.conacyt.mx/project/macrocelula/task/2701
https://project.crip.conacyt.mx/project/macrocelula/task/2722