### PR TITLE
Fix/tabindex elementos contraidos

### DIFF
--- a/docs/.vuepress/components/colapsable-navegacion/slot.vue
+++ b/docs/.vuepress/components/colapsable-navegacion/slot.vue
@@ -6,6 +6,7 @@
           href="#"
           class="nav-hipervinculo"
           exact
+          tabindex="-1"
           >Opción 1 desplegable</a
         >
       </li>
@@ -13,6 +14,7 @@
         <a
           href="#"
           class="nav-hipervinculo"
+          tabindex="-1"
           >Opción 2 desplegable</a
         >
       </li>

--- a/docs/.vuepress/components/menu-lateral/basico.vue
+++ b/docs/.vuepress/components/menu-lateral/basico.vue
@@ -2,15 +2,19 @@
   <div>
     <SisdaiMenuLateral>
       <template slot="contenido-menu-lateral">
-        <router-link
-          to="#api"
-          exact
-        >
-          API</router-link
-        >
-        <router-link to="#slots"> Slots</router-link>
-        <router-link to="#ejemplos"> Ejemplos </router-link>
-        <a href="#menu-lateral"> El mero inicio </a>
+        <ul>
+          <li>
+            <router-link
+              to="#api"
+              exact
+            >
+              API</router-link
+            >
+          </li>
+          <li><router-link to="#slots"> Slots</router-link></li>
+          <li><router-link to="#ejemplos"> Ejemplos </router-link></li>
+          <li><a href="#menu-lateral"> El mero inicio </a></li>
+        </ul>
       </template>
     </SisdaiMenuLateral>
   </div>

--- a/docs/.vuepress/components/menu-lateral/colapsable.vue
+++ b/docs/.vuepress/components/menu-lateral/colapsable.vue
@@ -18,8 +18,22 @@
             :titulo="'<SisdaiColapsableNavegacion> :D'"
           >
             <template v-slot:listado-contenido>
-              <li><router-link to="#ejemplos"> Ejemplos </router-link></li>
-              <li><a href="#menu-lateral"> El mero inicio </a></li>
+              <li>
+                <router-link
+                  to="#ejemplos"
+                  tabindex="-1"
+                >
+                  Ejemplos
+                </router-link>
+              </li>
+              <li>
+                <a
+                  href="#menu-lateral"
+                  tabindex="-1"
+                >
+                  El mero inicio
+                </a>
+              </li>
             </template>
           </SisdaiColapsableNavegacion>
         </ul>

--- a/docs/.vuepress/components/menu-lateral/colapsable.vue
+++ b/docs/.vuepress/components/menu-lateral/colapsable.vue
@@ -36,18 +36,20 @@
               </li>
             </template>
           </SisdaiColapsableNavegacion>
+          <li>
+            <a
+              href="##"
+              rel="noopener"
+              style="display: grid"
+            >
+              <span
+                class="icono-social-github titulo-eni"
+                aria-hidden="true"
+              ></span>
+              <span> ir a github</span>
+            </a>
+          </li>
         </ul>
-        <a
-          href="##"
-          rel="noopener"
-          style="display: grid"
-        >
-          <span
-            class="icono-social-github titulo-eni"
-            aria-hidden="true"
-          ></span>
-          <span> ir a github</span>
-        </a>
       </template>
     </SisdaiMenuLateral>
   </div>

--- a/docs/.vuepress/theme/layouts/LayoutDocumentacion.vue
+++ b/docs/.vuepress/theme/layouts/LayoutDocumentacion.vue
@@ -119,19 +119,21 @@ function actualizaContenidoIndice() {
                   PiePaginaGobMx
                 </router-link>
               </li>
+              <li>
+                <a
+                  href="https://github.com/salsa-community/sisdai-componentes"
+                  target="_blank"
+                  rel="noopener"
+                  style="display: grid"
+                >
+                  <span
+                    class="icono-social-github titulo-eni"
+                    aria-hidden="true"
+                  ></span>
+                  <span> ir a github</span>
+                </a>
+              </li>
             </ul>
-            <a
-              href="https://github.com/salsa-community/sisdai-componentes"
-              target="_blank"
-              rel="noopener"
-              style="display: grid"
-            >
-              <span
-                class="icono-social-github titulo-eni"
-                aria-hidden="true"
-              ></span>
-              <span> ir a github</span>
-            </a>
           </template>
         </SisdaiMenuLateral>
       </div>

--- a/docs/documentacion/colapsable-navegacion/index.md
+++ b/docs/documentacion/colapsable-navegacion/index.md
@@ -6,7 +6,7 @@ layout: LayoutDocumentacion
 
 Este componente consiste en un elemento `<li class="colapsable-navegacion"></li>` que contiene en su interior un botón y una lista no ordenada `<ul></ul>` que usualmente contendrá enlaces `<a></a>` en sus elementos de lista `<li></li>`,
 
-Su funcionalidad consiste en que al dar click al botón se pude agregar una clase `.activo` al elemnto `li.colapsable-navegacion`, lo cual hará que la lista no ordenada sea vuelva visible. Los estilos de las clases mencionadas anteriormente provienen de la biblioteca de estilos [sisdai-css](https://github.com/salsa-community/sisdai-css), por lo cual es una dependencia de este componente.
+Su funcionalidad consiste en que al dar click al botón se pude agregar una clase `.activo` al elemento `li.colapsable-navegacion`, lo cual hará que la lista no ordenada sea vuelva visible. Los estilos de las clases mencionadas anteriormente provienen de la biblioteca de estilos [sisdai-css](https://github.com/salsa-community/sisdai-css), por lo cual es una dependencia de este componente.
 
 Los elementos de lista se especifican mediante `slots`.
 
@@ -30,11 +30,12 @@ A continuación se enlistan las propiedades que admite el componente
 
 ### Slots
 
-- `'listado-contenido'`: Este es el único slot que contiene el componente, en él se deben indicar los elemtos de lista `<li></li>` que contendrá el elemento. Por _default_ tiene el siguiente `html` dentro del slot
+- `'listado-contenido'`: Este es el único slot que contiene el componente, en él se deben indicar los elementos de lista `<li></li>` que contendrá el elemento. Por _default_ tiene el siguiente `html` dentro del slot
 
 ```html
 <li>
   <a
+    tabindex="-1"
     href="#"
     exact
   >
@@ -44,6 +45,10 @@ A continuación se enlistan las propiedades que admite el componente
 ```
 
 Se debe agregar el atributo `exact` al primer elemento de la lista de navegación para que el estilo de la sección actual en el menú se active exactamente cuando la ruta esté selecionada.
+
+Se debe agregar el atributo `tabindex` a cada uno de los elementos de la lista de navegación, para que cuando se requiera navegar por teclado éste los identifique y los enfoque dependiendo si el menú está colapsado o no.
+
+En caso que de que el menú esté desplegado por defecto el atributo se puede omitir, puesto que las etiquetas `<a>` con atributo `href` son enfocables y tienen un valor predeterminado del `tabindex` en 0.
 
 </section>
 
@@ -63,6 +68,6 @@ Así se renderiza cuando especificamos un `:titulo` y su slot
 
 <utils-ejemplo-doc ruta="colapsable-navegacion/slot.vue"/>
 
-**Observación:** Este componente `<SisdaiColapsableNavegacion/>` tiene un estilo definido para el componente `<SisdaiMenuLateral/>`. Puedes consultar la sección de dicho componente para ver como pueden convivir
+**Observación:** Este componente `<SisdaiColapsableNavegacion/>` tiene un estilo definido para el componente `<SisdaiMenuLateral/>`. Puedes consultar la [sección](/documentacion/menu-lateral) de dicho componente para ver como pueden convivir.
 
 </section>

--- a/docs/documentacion/menu-lateral/index.md
+++ b/docs/documentacion/menu-lateral/index.md
@@ -23,21 +23,30 @@ Para este componente, el uso de [Vue Router](https://router.vuejs.org/) es altam
 Por _default_ el contenido del slot es el siguiente:
 
 ```html
-<router-link
-  to="#routerlink"
-  exact
->
-  router link prueba
-</router-link>
-<a href="#anchore"> anchore link prueba </a>
-<a
-  href="https://github.com/salsa-community/sisdai-componentes"
-  rel="noopener"
-  target="_blank"
->
-  <span class="icono-social-github"></span>
-  ejemplo github
-</a>
+<ul>
+  <li>
+    <router-link
+      to="#routerlink"
+      exact
+    >
+      router link prueba
+    </router-link>
+  </li>
+  <li><a href="#anchore"> anchore link prueba </a></li>
+  <li>
+    <a
+      href="https://github.com/salsa-community/sisdai-componentes"
+      rel="noopener"
+      target="_blank"
+    >
+      <span
+        class="icono-social-github"
+        aria-hidden="true"
+      ></span>
+      ejemplo github
+    </a>
+  </li>
+</ul>
 ```
 
 Se debe agregar el atributo `exact` al primer elemento de la lista de navegación para que el estilo de la sección actual en el menú se active exactamente cuando la ruta esté selecionada.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@popperjs/core": "^2.11.7",
         "core-js": "^3.31.0",
-        "sisdai-css": "github:salsa-community/sisdai-css#v0.37.12",
+        "sisdai-css": "github:salsa-community/sisdai-css#v0.37.13",
         "vue": "^2.7.14"
       },
       "devDependencies": {
@@ -3113,9 +3113,9 @@
       }
     },
     "node_modules/@vue/cli-plugin-babel/node_modules/terser": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.0.tgz",
-      "integrity": "sha512-JpcpGOQLOXm2jsomozdMDpd5f8ZHh1rR48OFgWUH3QsyZcfPgv2qDCYbcDEAYNd4OZRj2bWYKpwdll/udZCk/Q==",
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.1.tgz",
+      "integrity": "sha512-27hxBUVdV6GoNg1pKQ7Z5cbR6V9txPVyBA+FQw3BaZ1Wuzvztce5p156DaP0NVZNrMZZ+6iG9Syf7WgMNKDg2Q==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -3165,9 +3165,9 @@
       }
     },
     "node_modules/@vue/cli-plugin-babel/node_modules/webpack": {
-      "version": "5.88.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
-      "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
+      "version": "5.88.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
+      "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -3528,9 +3528,9 @@
       }
     },
     "node_modules/@vue/cli-plugin-eslint/node_modules/terser": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.0.tgz",
-      "integrity": "sha512-JpcpGOQLOXm2jsomozdMDpd5f8ZHh1rR48OFgWUH3QsyZcfPgv2qDCYbcDEAYNd4OZRj2bWYKpwdll/udZCk/Q==",
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.1.tgz",
+      "integrity": "sha512-27hxBUVdV6GoNg1pKQ7Z5cbR6V9txPVyBA+FQw3BaZ1Wuzvztce5p156DaP0NVZNrMZZ+6iG9Syf7WgMNKDg2Q==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -3643,9 +3643,9 @@
       }
     },
     "node_modules/@vue/cli-plugin-eslint/node_modules/webpack": {
-      "version": "5.88.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
-      "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
+      "version": "5.88.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
+      "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -4579,9 +4579,9 @@
       }
     },
     "node_modules/@vue/cli-service/node_modules/terser": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.0.tgz",
-      "integrity": "sha512-JpcpGOQLOXm2jsomozdMDpd5f8ZHh1rR48OFgWUH3QsyZcfPgv2qDCYbcDEAYNd4OZRj2bWYKpwdll/udZCk/Q==",
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.1.tgz",
+      "integrity": "sha512-27hxBUVdV6GoNg1pKQ7Z5cbR6V9txPVyBA+FQw3BaZ1Wuzvztce5p156DaP0NVZNrMZZ+6iG9Syf7WgMNKDg2Q==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -4631,9 +4631,9 @@
       }
     },
     "node_modules/@vue/cli-service/node_modules/webpack": {
-      "version": "5.88.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
-      "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
+      "version": "5.88.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
+      "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -7110,6 +7110,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.1.tgz",
+      "integrity": "sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "get-intrinsic": "^1.2.1",
+        "is-array-buffer": "^3.0.2",
+        "is-shared-array-buffer": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -8356,9 +8376,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001515",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
-      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
+      "version": "1.0.30001516",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001516.tgz",
+      "integrity": "sha512-Wmec9pCBY8CWbmI4HsjBeQLqDTqV91nFVR83DnZpYyRnPI1wePDsTg0bGLPC5VU/3OIZV1fmxEea1b+tFKe86g==",
       "dev": true,
       "funding": [
         {
@@ -10667,9 +10687,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.459",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.459.tgz",
-      "integrity": "sha512-XXRS5NFv8nCrBL74Rm3qhJjA2VCsRFx0OjHKBMPI0otij56aun8UWiKTDABmd5/7GTR021pA4wivs+Ri6XCElg==",
+      "version": "1.4.464",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.464.tgz",
+      "integrity": "sha512-guZ84yoou4+ILNdj0XEbmGs6DEWj6zpVOWYpY09GU66yEb0DSYvP/biBPzHn0GuW/3RC/pnaYNUWlQE1fJYtgA==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -10857,12 +10877,13 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.21.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.3.tgz",
-      "integrity": "sha512-ZU4miiY1j3sGPFLJ34VJXEqhpmL+HGByCinGHv4HC+Fxl2fI2Z4yR6tl0mORnDr6PA8eihWo4LmSWDbvhALckg==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.1.tgz",
+      "integrity": "sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==",
       "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
+        "arraybuffer.prototype.slice": "^1.0.1",
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-set-tostringtag": "^2.0.1",
@@ -10889,10 +10910,13 @@
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.5.0",
+        "safe-array-concat": "^1.0.0",
         "safe-regex-test": "^1.0.0",
         "string.prototype.trim": "^1.2.7",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
+        "typed-array-buffer": "^1.0.0",
+        "typed-array-byte-length": "^1.0.0",
         "typed-array-byte-offset": "^1.0.0",
         "typed-array-length": "^1.0.4",
         "unbox-primitive": "^1.0.2",
@@ -11238,9 +11262,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
-      "integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
+      "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -11268,7 +11292,6 @@
         "globals": "^13.19.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
@@ -11280,7 +11303,6 @@
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
       },
       "bin": {
@@ -11473,9 +11495,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.1.tgz",
+      "integrity": "sha512-CvefSOsDdaYYvxChovdrPo/ZGt8d5lrJWleAc1diXRKhHGiTYEI26cvo8Kle/wGnsizoCJjK73FMg1/IkIwiNA==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -11558,9 +11580,9 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-      "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.9.0",
@@ -13308,9 +13330,9 @@
       }
     },
     "node_modules/html-minifier-terser/node_modules/terser": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.0.tgz",
-      "integrity": "sha512-JpcpGOQLOXm2jsomozdMDpd5f8ZHh1rR48OFgWUH3QsyZcfPgv2qDCYbcDEAYNd4OZRj2bWYKpwdll/udZCk/Q==",
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.1.tgz",
+      "integrity": "sha512-27hxBUVdV6GoNg1pKQ7Z5cbR6V9txPVyBA+FQw3BaZ1Wuzvztce5p156DaP0NVZNrMZZ+6iG9Syf7WgMNKDg2Q==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -14350,16 +14372,12 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
       "dev": true,
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "which-typed-array": "^1.1.11"
       },
       "engines": {
         "node": ">= 0.4"
@@ -18049,9 +18067,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.25",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.25.tgz",
-      "integrity": "sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==",
+      "version": "8.4.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.26.tgz",
+      "integrity": "sha512-jrXHFF8iTloAenySjM/ob3gSj7pCu0Ji49hnjqzsgSRa50hkWCKD0HQ+gMNJkW38jBI68MpAAg7ZWwHwX8NMMw==",
       "funding": [
         {
           "type": "opencollective",
@@ -20525,8 +20543,8 @@
       }
     },
     "node_modules/sisdai-css": {
-      "version": "0.37.12",
-      "resolved": "git+ssh://git@github.com/salsa-community/sisdai-css.git#fa7dce2457ccc7e329fa300c424d1d84ae2994ae",
+      "version": "0.37.13",
+      "resolved": "git+ssh://git@github.com/salsa-community/sisdai-css.git#e10e86502438f847e58ea238854688c0b7648985",
       "dependencies": {
         "sass": "1.49.10"
       }
@@ -22120,6 +22138,38 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
+      "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.1",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
+      "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "has-proto": "^1.0.1",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
@@ -22800,9 +22850,9 @@
       }
     },
     "node_modules/vue-eslint-parser/node_modules/eslint-scope": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.1.tgz",
+      "integrity": "sha512-CvefSOsDdaYYvxChovdrPo/ZGt8d5lrJWleAc1diXRKhHGiTYEI26cvo8Kle/wGnsizoCJjK73FMg1/IkIwiNA==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -24500,9 +24550,9 @@
       }
     },
     "node_modules/whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "version": "3.6.16",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.16.tgz",
+      "integrity": "sha512-83avoGbZ0qtjtNrU3UTT3/Xd3uZ7DyfSYLuc1fL5iYs+93P+UkIVF6/6xpRVWeQcvbc7kSnVybSAVbd6QFW5Fg==",
       "dev": true
     },
     "node_modules/whatwg-url": {
@@ -24559,17 +24609,16 @@
       "dev": true
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.10.tgz",
-      "integrity": "sha512-uxoA5vLUfRPdjCuJ1h5LlYdmTLbYfums398v3WLkM+i/Wltl2/XyZpQWKbN++ck5L64SR/grOHqtXCUKmlZPNA==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
       "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.10"
+        "has-tostringtag": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -27255,9 +27304,9 @@
           "dev": true
         },
         "terser": {
-          "version": "5.19.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.0.tgz",
-          "integrity": "sha512-JpcpGOQLOXm2jsomozdMDpd5f8ZHh1rR48OFgWUH3QsyZcfPgv2qDCYbcDEAYNd4OZRj2bWYKpwdll/udZCk/Q==",
+          "version": "5.19.1",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.1.tgz",
+          "integrity": "sha512-27hxBUVdV6GoNg1pKQ7Z5cbR6V9txPVyBA+FQw3BaZ1Wuzvztce5p156DaP0NVZNrMZZ+6iG9Syf7WgMNKDg2Q==",
           "dev": true,
           "requires": {
             "@jridgewell/source-map": "^0.3.3",
@@ -27280,9 +27329,9 @@
           }
         },
         "webpack": {
-          "version": "5.88.1",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
-          "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
+          "version": "5.88.2",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
+          "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
           "dev": true,
           "requires": {
             "@types/eslint-scope": "^3.7.3",
@@ -27577,9 +27626,9 @@
           "dev": true
         },
         "terser": {
-          "version": "5.19.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.0.tgz",
-          "integrity": "sha512-JpcpGOQLOXm2jsomozdMDpd5f8ZHh1rR48OFgWUH3QsyZcfPgv2qDCYbcDEAYNd4OZRj2bWYKpwdll/udZCk/Q==",
+          "version": "5.19.1",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.1.tgz",
+          "integrity": "sha512-27hxBUVdV6GoNg1pKQ7Z5cbR6V9txPVyBA+FQw3BaZ1Wuzvztce5p156DaP0NVZNrMZZ+6iG9Syf7WgMNKDg2Q==",
           "dev": true,
           "requires": {
             "@jridgewell/source-map": "^0.3.3",
@@ -27651,9 +27700,9 @@
           }
         },
         "webpack": {
-          "version": "5.88.1",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
-          "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
+          "version": "5.88.2",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
+          "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
           "dev": true,
           "requires": {
             "@types/eslint-scope": "^3.7.3",
@@ -28325,9 +28374,9 @@
           "dev": true
         },
         "terser": {
-          "version": "5.19.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.0.tgz",
-          "integrity": "sha512-JpcpGOQLOXm2jsomozdMDpd5f8ZHh1rR48OFgWUH3QsyZcfPgv2qDCYbcDEAYNd4OZRj2bWYKpwdll/udZCk/Q==",
+          "version": "5.19.1",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.1.tgz",
+          "integrity": "sha512-27hxBUVdV6GoNg1pKQ7Z5cbR6V9txPVyBA+FQw3BaZ1Wuzvztce5p156DaP0NVZNrMZZ+6iG9Syf7WgMNKDg2Q==",
           "dev": true,
           "requires": {
             "@jridgewell/source-map": "^0.3.3",
@@ -28350,9 +28399,9 @@
           }
         },
         "webpack": {
-          "version": "5.88.1",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
-          "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
+          "version": "5.88.2",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
+          "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
           "dev": true,
           "requires": {
             "@types/eslint-scope": "^3.7.3",
@@ -30385,6 +30434,20 @@
         "is-string": "^1.0.7"
       }
     },
+    "arraybuffer.prototype.slice": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.1.tgz",
+      "integrity": "sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==",
+      "dev": true,
+      "requires": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "get-intrinsic": "^1.2.1",
+        "is-array-buffer": "^3.0.2",
+        "is-shared-array-buffer": "^1.0.2"
+      }
+    },
     "asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -31370,9 +31433,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001515",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
-      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
+      "version": "1.0.30001516",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001516.tgz",
+      "integrity": "sha512-Wmec9pCBY8CWbmI4HsjBeQLqDTqV91nFVR83DnZpYyRnPI1wePDsTg0bGLPC5VU/3OIZV1fmxEea1b+tFKe86g==",
       "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {
@@ -33200,9 +33263,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.459",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.459.tgz",
-      "integrity": "sha512-XXRS5NFv8nCrBL74Rm3qhJjA2VCsRFx0OjHKBMPI0otij56aun8UWiKTDABmd5/7GTR021pA4wivs+Ri6XCElg==",
+      "version": "1.4.464",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.464.tgz",
+      "integrity": "sha512-guZ84yoou4+ILNdj0XEbmGs6DEWj6zpVOWYpY09GU66yEb0DSYvP/biBPzHn0GuW/3RC/pnaYNUWlQE1fJYtgA==",
       "dev": true
     },
     "elliptic": {
@@ -33364,12 +33427,13 @@
       }
     },
     "es-abstract": {
-      "version": "1.21.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.3.tgz",
-      "integrity": "sha512-ZU4miiY1j3sGPFLJ34VJXEqhpmL+HGByCinGHv4HC+Fxl2fI2Z4yR6tl0mORnDr6PA8eihWo4LmSWDbvhALckg==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.1.tgz",
+      "integrity": "sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==",
       "dev": true,
       "requires": {
         "array-buffer-byte-length": "^1.0.0",
+        "arraybuffer.prototype.slice": "^1.0.1",
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-set-tostringtag": "^2.0.1",
@@ -33396,10 +33460,13 @@
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.5.0",
+        "safe-array-concat": "^1.0.0",
         "safe-regex-test": "^1.0.0",
         "string.prototype.trim": "^1.2.7",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
+        "typed-array-buffer": "^1.0.0",
+        "typed-array-byte-length": "^1.0.0",
         "typed-array-byte-offset": "^1.0.0",
         "typed-array-length": "^1.0.4",
         "unbox-primitive": "^1.0.2",
@@ -33615,9 +33682,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
-      "integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
+      "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -33645,7 +33712,6 @@
         "globals": "^13.19.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
@@ -33657,7 +33723,6 @@
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
       },
       "dependencies": {
@@ -33702,9 +33767,9 @@
           "dev": true
         },
         "eslint-scope": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-          "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.1.tgz",
+          "integrity": "sha512-CvefSOsDdaYYvxChovdrPo/ZGt8d5lrJWleAc1diXRKhHGiTYEI26cvo8Kle/wGnsizoCJjK73FMg1/IkIwiNA==",
           "dev": true,
           "requires": {
             "esrecurse": "^4.3.0",
@@ -33838,9 +33903,9 @@
       "dev": true
     },
     "espree": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-      "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "requires": {
         "acorn": "^8.9.0",
@@ -35252,9 +35317,9 @@
           }
         },
         "terser": {
-          "version": "5.19.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.0.tgz",
-          "integrity": "sha512-JpcpGOQLOXm2jsomozdMDpd5f8ZHh1rR48OFgWUH3QsyZcfPgv2qDCYbcDEAYNd4OZRj2bWYKpwdll/udZCk/Q==",
+          "version": "5.19.1",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.1.tgz",
+          "integrity": "sha512-27hxBUVdV6GoNg1pKQ7Z5cbR6V9txPVyBA+FQw3BaZ1Wuzvztce5p156DaP0NVZNrMZZ+6iG9Syf7WgMNKDg2Q==",
           "dev": true,
           "requires": {
             "@jridgewell/source-map": "^0.3.3",
@@ -36012,16 +36077,12 @@
       }
     },
     "is-typed-array": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
       "dev": true,
       "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "which-typed-array": "^1.1.11"
       }
     },
     "is-typedarray": {
@@ -39008,9 +39069,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.25",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.25.tgz",
-      "integrity": "sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==",
+      "version": "8.4.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.26.tgz",
+      "integrity": "sha512-jrXHFF8iTloAenySjM/ob3gSj7pCu0Ji49hnjqzsgSRa50hkWCKD0HQ+gMNJkW38jBI68MpAAg7ZWwHwX8NMMw==",
       "requires": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -40847,8 +40908,8 @@
       }
     },
     "sisdai-css": {
-      "version": "git+ssh://git@github.com/salsa-community/sisdai-css.git#fa7dce2457ccc7e329fa300c424d1d84ae2994ae",
-      "from": "sisdai-css@github:salsa-community/sisdai-css#v0.37.12",
+      "version": "git+ssh://git@github.com/salsa-community/sisdai-css.git#e10e86502438f847e58ea238854688c0b7648985",
+      "from": "sisdai-css@github:salsa-community/sisdai-css#v0.37.13",
       "requires": {
         "sass": "1.49.10"
       },
@@ -42139,6 +42200,29 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typed-array-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
+      "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.1",
+        "is-typed-array": "^1.1.10"
+      }
+    },
+    "typed-array-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
+      "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "has-proto": "^1.0.1",
+        "is-typed-array": "^1.1.10"
+      }
+    },
     "typed-array-byte-offset": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
@@ -42677,9 +42761,9 @@
       },
       "dependencies": {
         "eslint-scope": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-          "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.1.tgz",
+          "integrity": "sha512-CvefSOsDdaYYvxChovdrPo/ZGt8d5lrJWleAc1diXRKhHGiTYEI26cvo8Kle/wGnsizoCJjK73FMg1/IkIwiNA==",
           "dev": true,
           "requires": {
             "esrecurse": "^4.3.0",
@@ -43988,9 +44072,9 @@
       "dev": true
     },
     "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "version": "3.6.16",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.16.tgz",
+      "integrity": "sha512-83avoGbZ0qtjtNrU3UTT3/Xd3uZ7DyfSYLuc1fL5iYs+93P+UkIVF6/6xpRVWeQcvbc7kSnVybSAVbd6QFW5Fg==",
       "dev": true
     },
     "whatwg-url": {
@@ -44038,17 +44122,16 @@
       "dev": true
     },
     "which-typed-array": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.10.tgz",
-      "integrity": "sha512-uxoA5vLUfRPdjCuJ1h5LlYdmTLbYfums398v3WLkM+i/Wltl2/XyZpQWKbN++ck5L64SR/grOHqtXCUKmlZPNA==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
       "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.10"
+        "has-tostringtag": "^1.0.0"
       }
     },
     "widest-line": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@popperjs/core": "^2.11.7",
     "core-js": "^3.31.0",
-    "sisdai-css": "github:salsa-community/sisdai-css#v0.37.12",
+    "sisdai-css": "github:salsa-community/sisdai-css#v0.37.13",
     "vue": "^2.7.14"
   },
   "devDependencies": {

--- a/src/componentes/colapsable-navegacion/SisdaiColapsableNavegacion.vue
+++ b/src/componentes/colapsable-navegacion/SisdaiColapsableNavegacion.vue
@@ -17,7 +17,7 @@ const listadoContenido = ref({})
 
 /**
  * Agrega el atributo tabindex a los elementos de lista,
- * si está cerrado
+ * si la navegación está colapsada
  */
 function agregaAtributoTabIndex() {
   if (esta_activo.value === false) {

--- a/src/componentes/colapsable-navegacion/SisdaiColapsableNavegacion.vue
+++ b/src/componentes/colapsable-navegacion/SisdaiColapsableNavegacion.vue
@@ -1,3 +1,62 @@
+<script setup>
+import { onMounted, ref, watch } from 'vue'
+
+const props = defineProps({
+  titulo: { type: String, default: 'Titulo de colapsable' },
+  activo: { type: Boolean, default: false },
+})
+const esta_activo = ref(props.activo)
+
+function idAleatorio() {
+  return Math.random().toString(36).substring(2)
+}
+
+const id_aleatorio = idAleatorio()
+
+const listadoContenido = ref({})
+
+/**
+ * Agrega el atributo tabindex a los elementos de lista,
+ * si está cerrado
+ */
+function agregaAtributoTabIndex() {
+  if (esta_activo.value === false) {
+    for (let index = 0; index < listadoContenido.value.length; index++) {
+      const elemento = listadoContenido.value[index]['children'][0]
+      elemento.tabIndex = '-1'
+    }
+  }
+}
+
+/**
+ * Si el menú está desplegado, remueve el atributo tabIndex.
+ * Si está colapsado, agrega el atributo tabIndex en -1 para
+ * saltarse los enlaces con el teclado secuencial.
+ */
+function actualizaAtributoTabIndex(estaAbierto) {
+  if (estaAbierto) {
+    for (let index = 0; index < listadoContenido.value.length; index++) {
+      const elemento = listadoContenido.value[index]['children'][0]
+      elemento.removeAttribute('tabIndex')
+    }
+  } else {
+    for (let index = 0; index < listadoContenido.value.length; index++) {
+      const elemento = listadoContenido.value[index]['children'][0]
+      elemento.tabIndex = '-1'
+    }
+  }
+}
+
+onMounted(() => {
+  listadoContenido.value = document.getElementById(id_aleatorio)['children']
+  agregaAtributoTabIndex()
+})
+
+watch(esta_activo, () => {
+  actualizaAtributoTabIndex(esta_activo.value)
+})
+</script>
+
 <template>
   <li
     :class="{ activo: esta_activo }"
@@ -14,7 +73,10 @@
         class="nav-boton-submenu"
       ></span>
     </button>
-    <ul class="colapsable-submenu">
+    <ul
+      :id="id_aleatorio"
+      class="colapsable-submenu"
+    >
       <slot name="listado-contenido">
         <li>
           <a
@@ -29,32 +91,3 @@
     </ul>
   </li>
 </template>
-
-<script setup>
-import { ref, watch } from 'vue'
-
-const props = defineProps({
-  titulo: { type: String, default: 'Titulo de colapsable' },
-  activo: { type: Boolean, default: false },
-})
-const esta_activo = ref(props.activo)
-
-/**
- * Si el menú está desplegado, remueve el atributo tabIndex.
- * Si está colapsado, agrega el atributo tabIndex en -1 para
- * saltarse los enlaces con el teclado secuencial.
- */
-watch(esta_activo, () => {
-  const contenidoLista = document.getElementsByTagName('a')
-
-  if (esta_activo.value) {
-    for (var i = 0; i < contenidoLista.length; i++) {
-      contenidoLista[i].removeAttribute('tabIndex')
-    }
-  } else {
-    for (var j = 0; j < contenidoLista.length; j++) {
-      contenidoLista[j].tabIndex = '-1'
-    }
-  }
-})
-</script>

--- a/src/componentes/colapsable-navegacion/SisdaiColapsableNavegacion.vue
+++ b/src/componentes/colapsable-navegacion/SisdaiColapsableNavegacion.vue
@@ -20,6 +20,7 @@
           <a
             href="https://github.com/salsa-community/sisdai-componentes/"
             target="_blank"
+            tabindex="-1"
           >
             Elemento desplegado</a
           >
@@ -30,11 +31,30 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 
 const props = defineProps({
   titulo: { type: String, default: 'Titulo de colapsable' },
   activo: { type: Boolean, default: false },
 })
 const esta_activo = ref(props.activo)
+
+/**
+ * Si el menú está desplegado, remueve el atributo tabIndex.
+ * Si está colapsado, agrega el atributo tabIndex en -1 para
+ * saltarse los enlaces con el teclado secuencial.
+ */
+watch(esta_activo, () => {
+  const contenidoLista = document.getElementsByTagName('a')
+
+  if (esta_activo.value) {
+    for (var i = 0; i < contenidoLista.length; i++) {
+      contenidoLista[i].removeAttribute('tabIndex')
+    }
+  } else {
+    for (var j = 0; j < contenidoLista.length; j++) {
+      contenidoLista[j].tabIndex = '-1'
+    }
+  }
+})
 </script>

--- a/src/componentes/menu-accesibilidad/SisdaiMenuAccesibilidad.vue
+++ b/src/componentes/menu-accesibilidad/SisdaiMenuAccesibilidad.vue
@@ -115,8 +115,8 @@ defineExpose({ alternarEstado })
  * Si está cerrado, agrega el atributo tabIndex en -1 para
  * saltarse las opciones con el teclado secuencial.
  */
-watch(menuAccesibilidadEstaAbierto, () => {
-  if (menuAccesibilidadEstaAbierto.value) {
+function actualizaAtributoTabIndex(estaAbierto) {
+  if (estaAbierto) {
     opciones.value.forEach((element, idx) => {
       document
         .getElementById(`opcion_accesibilidad_${idx}`)
@@ -131,6 +131,10 @@ watch(menuAccesibilidadEstaAbierto, () => {
     })
     document.getElementById('opcion_accesibilidad_restablecer').tabIndex = '-1'
   }
+}
+
+watch(menuAccesibilidadEstaAbierto, () => {
+  actualizaAtributoTabIndex(menuAccesibilidadEstaAbierto.value)
 })
 
 /**

--- a/src/componentes/menu-lateral/SisdaiMenuLateral.vue
+++ b/src/componentes/menu-lateral/SisdaiMenuLateral.vue
@@ -8,7 +8,6 @@ function idAleatorio() {
 
 const id_aleatorio = idAleatorio()
 
-// const menuColapsable = document.getElementsByClassName('menu-colapsable')
 const elementosLista = ref({})
 
 /**

--- a/src/componentes/menu-lateral/SisdaiMenuLateral.vue
+++ b/src/componentes/menu-lateral/SisdaiMenuLateral.vue
@@ -1,3 +1,55 @@
+<script setup>
+import { onMounted, ref, watch } from 'vue'
+const menu_abierto = ref(false)
+
+const menuColapsable = document.getElementsByClassName('menu-colapsable')
+const elementosLista = ref({})
+
+/**
+ * Agrega el atributo tabindex a los elementos de lista,
+ * si está en versión móvil
+ */
+function agregaAtributoTabIndex() {
+  if (window.innerWidth < 768) {
+    for (let index = 0; index < elementosLista.value.length; index++) {
+      const elemento = elementosLista.value[index]['children'][0]
+      elemento.tabIndex = '-1'
+    }
+  }
+}
+
+/**
+ * Si el menú está abierto en móvil, remueve el atributo tabIndex.
+ * Si está cerrado, agrega el atributo tabIndex en -1 para
+ * saltarse los enlaces con el teclado secuencial.
+ */
+function actualizaAtributoTabIndex(estaAbierto) {
+  if (window.innerWidth < 768) {
+    if (estaAbierto) {
+      for (let i = 0; i < elementosLista.value.length; i++) {
+        const elemento = elementosLista.value[i]['children'][0]
+        elemento.removeAttribute('tabIndex')
+      }
+    } else {
+      for (let j = 0; j < elementosLista.value.length; j++) {
+        const elemento = elementosLista.value[j]['children'][0]
+        elemento.tabIndex = '-1'
+      }
+    }
+  }
+}
+
+onMounted(() => {
+  elementosLista.value =
+    menuColapsable[0]['children'][0]['children'][0]['children']
+  agregaAtributoTabIndex()
+})
+
+watch(menu_abierto, () => {
+  actualizaAtributoTabIndex(menu_abierto.value)
+})
+</script>
+
 <template>
   <nav
     class="menu-lateral-contenedor"
@@ -60,55 +112,3 @@
     </div>
   </nav>
 </template>
-
-<script setup>
-import { onMounted, ref, watch } from 'vue'
-const menu_abierto = ref(false)
-
-const menuColapsable = document.getElementsByClassName('menu-colapsable')
-const elementosLista = ref({})
-
-/**
- * Agrega el atributo tabindex a los elementos de lista,
- * si está en versión móvil
- */
-function agregaAtributoTabIndex() {
-  if (window.innerWidth < 768) {
-    for (let index = 0; index < elementosLista.value.length; index++) {
-      const elemento = elementosLista.value[index]['children'][0]
-      elemento.tabIndex = '-1'
-    }
-  }
-}
-
-/**
- * Si el menú está abierto en móvil, remueve el atributo tabIndex.
- * Si está cerrado, agrega el atributo tabIndex en -1 para
- * saltarse los enlaces con el teclado secuencial.
- */
-function actualizaAtributoTabIndex(estaAbierto) {
-  if (window.innerWidth < 768) {
-    if (estaAbierto) {
-      for (let i = 0; i < elementosLista.value.length; i++) {
-        const elemento = elementosLista.value[i]['children'][0]
-        elemento.removeAttribute('tabIndex')
-      }
-    } else {
-      for (let j = 0; j < elementosLista.value.length; j++) {
-        const elemento = elementosLista.value[j]['children'][0]
-        elemento.tabIndex = '-1'
-      }
-    }
-  }
-}
-
-onMounted(() => {
-  elementosLista.value =
-    menuColapsable[0]['children'][0]['children'][0]['children']
-  agregaAtributoTabIndex()
-})
-
-watch(menu_abierto, () => {
-  actualizaAtributoTabIndex(menu_abierto.value)
-})
-</script>

--- a/src/componentes/menu-lateral/SisdaiMenuLateral.vue
+++ b/src/componentes/menu-lateral/SisdaiMenuLateral.vue
@@ -31,24 +31,30 @@
     >
       <div class="menu-max-height">
         <slot name="contenido-menu-lateral">
-          <router-link
-            to="#routerlink"
-            exact
-          >
-            router link prueba
-          </router-link>
-          <a href="#anchore"> anchore link prueba </a>
-          <a
-            href="https://github.com/salsa-community/sisdai-componentes"
-            rel="noopener"
-            target="_blank"
-          >
-            <span
-              class="icono-social-github"
-              aria-hidden="true"
-            ></span>
-            ejemplo github
-          </a>
+          <ul>
+            <li>
+              <router-link
+                to="#routerlink"
+                exact
+              >
+                router link prueba
+              </router-link>
+            </li>
+            <li><a href="#anchore"> anchore link prueba </a></li>
+            <li>
+              <a
+                href="https://github.com/salsa-community/sisdai-componentes"
+                rel="noopener"
+                target="_blank"
+              >
+                <span
+                  class="icono-social-github"
+                  aria-hidden="true"
+                ></span>
+                ejemplo github
+              </a>
+            </li>
+          </ul>
         </slot>
       </div>
     </div>
@@ -56,6 +62,53 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { onMounted, ref, watch } from 'vue'
 const menu_abierto = ref(false)
+
+const menuColapsable = document.getElementsByClassName('menu-colapsable')
+const elementosLista = ref({})
+
+/**
+ * Agrega el atributo tabindex a los elementos de lista,
+ * si está en versión móvil
+ */
+function agregaAtributoTabIndex() {
+  if (window.innerWidth < 768) {
+    for (let index = 0; index < elementosLista.value.length; index++) {
+      const elemento = elementosLista.value[index]['children'][0]
+      elemento.tabIndex = '-1'
+    }
+  }
+}
+
+/**
+ * Si el menú está abierto en móvil, remueve el atributo tabIndex.
+ * Si está cerrado, agrega el atributo tabIndex en -1 para
+ * saltarse los enlaces con el teclado secuencial.
+ */
+function actualizaAtributoTabIndex(estaAbierto) {
+  if (window.innerWidth < 768) {
+    if (estaAbierto) {
+      for (let i = 0; i < elementosLista.value.length; i++) {
+        const elemento = elementosLista.value[i]['children'][0]
+        elemento.removeAttribute('tabIndex')
+      }
+    } else {
+      for (let j = 0; j < elementosLista.value.length; j++) {
+        const elemento = elementosLista.value[j]['children'][0]
+        elemento.tabIndex = '-1'
+      }
+    }
+  }
+}
+
+onMounted(() => {
+  elementosLista.value =
+    menuColapsable[0]['children'][0]['children'][0]['children']
+  agregaAtributoTabIndex()
+})
+
+watch(menu_abierto, () => {
+  actualizaAtributoTabIndex(menu_abierto.value)
+})
 </script>

--- a/src/componentes/menu-lateral/SisdaiMenuLateral.vue
+++ b/src/componentes/menu-lateral/SisdaiMenuLateral.vue
@@ -2,7 +2,13 @@
 import { onMounted, ref, watch } from 'vue'
 const menu_abierto = ref(false)
 
-const menuColapsable = document.getElementsByClassName('menu-colapsable')
+function idAleatorio() {
+  return Math.random().toString(36).substring(2)
+}
+
+const id_aleatorio = idAleatorio()
+
+// const menuColapsable = document.getElementsByClassName('menu-colapsable')
 const elementosLista = ref({})
 
 /**
@@ -41,7 +47,9 @@ function actualizaAtributoTabIndex(estaAbierto) {
 
 onMounted(() => {
   elementosLista.value =
-    menuColapsable[0]['children'][0]['children'][0]['children']
+    document.getElementById(id_aleatorio)['children'][0]['children'][0][
+      'children'
+    ]
   agregaAtributoTabIndex()
 })
 
@@ -78,6 +86,7 @@ watch(menu_abierto, () => {
       </button>
     </div>
     <div
+      :id="id_aleatorio"
       class="menu-colapsable"
       :class="{ abierto: menu_abierto }"
     >

--- a/src/componentes/navegacion-gob-mx/SisdaiNavegacionGobMx.vue
+++ b/src/componentes/navegacion-gob-mx/SisdaiNavegacionGobMx.vue
@@ -108,7 +108,7 @@ const cuadroElementosMenu = ref(null)
 const { menuEstaAbierto, alternarMenu } =
   useMenuDesenfocable(cuadroElementosMenu)
 
-const navMenuGobMx = document.getElementsByClassName('nav-menu')[0]['children']
+const navMenuGobMx = ref({})
 
 /**
  * Agrega el atributo tabindex a los elementos de lista,
@@ -116,8 +116,8 @@ const navMenuGobMx = document.getElementsByClassName('nav-menu')[0]['children']
  */
 function agregaAtributoTabIndex() {
   if (window.innerWidth < 768) {
-    for (let index = 0; index < navMenuGobMx.length; index++) {
-      const elemento = navMenuGobMx[index]['children'][0]
+    for (let index = 0; index < navMenuGobMx.value.length; index++) {
+      const elemento = navMenuGobMx.value[index]['children'][0]
       elemento.tabIndex = '-1'
     }
   }
@@ -131,13 +131,13 @@ function agregaAtributoTabIndex() {
 function actualizaAtributoTabIndex(estaAbierto) {
   if (window.innerWidth < 768) {
     if (estaAbierto) {
-      for (let i = 0; i < navMenuGobMx.length; i++) {
-        const elemento = navMenuGobMx[i]['children'][0]
+      for (let i = 0; i < navMenuGobMx.value.length; i++) {
+        const elemento = navMenuGobMx.value[i]['children'][0]
         elemento.removeAttribute('tabIndex')
       }
     } else {
-      for (let j = 0; j < navMenuGobMx.length; j++) {
-        const elemento = navMenuGobMx[j]['children'][0]
+      for (let j = 0; j < navMenuGobMx.value.length; j++) {
+        const elemento = navMenuGobMx.value[j]['children'][0]
         elemento.tabIndex = '-1'
       }
     }
@@ -145,6 +145,8 @@ function actualizaAtributoTabIndex(estaAbierto) {
 }
 
 onMounted(() => {
+  navMenuGobMx.value =
+    document.getElementsByClassName('nav-menu')[0]['children']
   agregaAtributoTabIndex()
 })
 

--- a/src/componentes/navegacion-gob-mx/SisdaiNavegacionGobMx.vue
+++ b/src/componentes/navegacion-gob-mx/SisdaiNavegacionGobMx.vue
@@ -39,7 +39,10 @@
         ref="cuadroElementosMenu"
         @click="alternarMenu"
       >
-        <ul class="nav-menu">
+        <ul
+          id="nav_menu_gobmx"
+          class="nav-menu"
+        >
           <li>
             <a
               href="https://mivacuna.salud.gob.mx/index.php"
@@ -105,7 +108,7 @@ const cuadroElementosMenu = ref(null)
 const { menuEstaAbierto, alternarMenu } =
   useMenuDesenfocable(cuadroElementosMenu)
 
-const navMenu = document.getElementsByClassName('nav-menu')
+const navMenuGobMx = document.getElementsByClassName('nav-menu')[0]['children']
 
 /**
  * Agrega el atributo tabindex a los elementos de lista,
@@ -113,9 +116,9 @@ const navMenu = document.getElementsByClassName('nav-menu')
  */
 function agregaAtributoTabIndex() {
   if (window.innerWidth < 768) {
-    for (let index = 0; index < navMenu[0]['children'].length; index++) {
-      const element = navMenu[0]['children'][index]['children'][0]
-      element.tabIndex = '-1'
+    for (let index = 0; index < navMenuGobMx.length; index++) {
+      const elemento = navMenuGobMx[index]['children'][0]
+      elemento.tabIndex = '-1'
     }
   }
 }
@@ -128,14 +131,14 @@ function agregaAtributoTabIndex() {
 function actualizaAtributoTabIndex(estaAbierto) {
   if (window.innerWidth < 768) {
     if (estaAbierto) {
-      for (let i = 0; i < navMenu[0]['children'].length; i++) {
-        const element = navMenu[0]['children'][i]['children'][0]
-        element.removeAttribute('tabIndex')
+      for (let i = 0; i < navMenuGobMx.length; i++) {
+        const elemento = navMenuGobMx[i]['children'][0]
+        elemento.removeAttribute('tabIndex')
       }
     } else {
-      for (let j = 0; j < navMenu[0]['children'].length; j++) {
-        const element = navMenu[0]['children'][j]['children'][0]
-        element.tabIndex = '-1'
+      for (let j = 0; j < navMenuGobMx.length; j++) {
+        const elemento = navMenuGobMx[j]['children'][0]
+        elemento.tabIndex = '-1'
       }
     }
   }

--- a/src/componentes/navegacion-gob-mx/SisdaiNavegacionGobMx.vue
+++ b/src/componentes/navegacion-gob-mx/SisdaiNavegacionGobMx.vue
@@ -97,11 +97,43 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { useMenuDesenfocable } from '../../composables/useMenuDesenfocable'
 
 //Que el menu se pueda cerrar automaticamente al enfocar otra cosa
 const cuadroElementosMenu = ref(null)
 const { menuEstaAbierto, alternarMenu } =
   useMenuDesenfocable(cuadroElementosMenu)
+
+/**
+ * Si el menú está abierto en móvil, remueve el atributo tabIndex.
+ * Si está cerrado, agrega el atributo tabIndex en -1 para
+ * saltarse los enlaces con el teclado secuencial.
+ */
+watch(menuEstaAbierto, () => {
+  const listadoContenido = document.getElementsByClassName('nav-menu')
+  if (window.innerWidth < 768) {
+    if (menuEstaAbierto.value) {
+      console.log('submenu abierto')
+      for (
+        let index = 0;
+        index < listadoContenido[0]['children'].length;
+        index++
+      ) {
+        const element = listadoContenido[0]['children'][index]['children'][0]
+        element.removeAttribute('tabIndex')
+      }
+    } else {
+      console.log('submenu cerrado')
+      for (
+        let index = 0;
+        index < listadoContenido[0]['children'].length;
+        index++
+      ) {
+        const element = listadoContenido[0]['children'][index]['children'][0]
+        element.tabIndex = '-1'
+      }
+    }
+  }
+})
 </script>

--- a/src/componentes/navegacion-gob-mx/SisdaiNavegacionGobMx.vue
+++ b/src/componentes/navegacion-gob-mx/SisdaiNavegacionGobMx.vue
@@ -97,7 +97,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { onMounted, ref, watch } from 'vue'
 import { useMenuDesenfocable } from '../../composables/useMenuDesenfocable'
 
 //Que el menu se pueda cerrar automaticamente al enfocar otra cosa
@@ -105,35 +105,47 @@ const cuadroElementosMenu = ref(null)
 const { menuEstaAbierto, alternarMenu } =
   useMenuDesenfocable(cuadroElementosMenu)
 
+const navMenu = document.getElementsByClassName('nav-menu')
+
+/**
+ * Agrega el atributo tabindex a los elementos de lista,
+ * si está en versión móvil
+ */
+function agregaAtributoTabIndex() {
+  if (window.innerWidth < 768) {
+    for (let index = 0; index < navMenu[0]['children'].length; index++) {
+      const element = navMenu[0]['children'][index]['children'][0]
+      element.tabIndex = '-1'
+    }
+  }
+}
+
 /**
  * Si el menú está abierto en móvil, remueve el atributo tabIndex.
  * Si está cerrado, agrega el atributo tabIndex en -1 para
  * saltarse los enlaces con el teclado secuencial.
  */
-watch(menuEstaAbierto, () => {
-  const listadoContenido = document.getElementsByClassName('nav-menu')
+function actualizaAtributoTabIndex(estaAbierto) {
   if (window.innerWidth < 768) {
-    if (menuEstaAbierto.value) {
-      console.log('submenu abierto')
-      for (
-        let index = 0;
-        index < listadoContenido[0]['children'].length;
-        index++
-      ) {
-        const element = listadoContenido[0]['children'][index]['children'][0]
+    if (estaAbierto) {
+      for (let i = 0; i < navMenu[0]['children'].length; i++) {
+        const element = navMenu[0]['children'][i]['children'][0]
         element.removeAttribute('tabIndex')
       }
     } else {
-      console.log('submenu cerrado')
-      for (
-        let index = 0;
-        index < listadoContenido[0]['children'].length;
-        index++
-      ) {
-        const element = listadoContenido[0]['children'][index]['children'][0]
+      for (let j = 0; j < navMenu[0]['children'].length; j++) {
+        const element = navMenu[0]['children'][j]['children'][0]
         element.tabIndex = '-1'
       }
     }
   }
+}
+
+onMounted(() => {
+  agregaAtributoTabIndex()
+})
+
+watch(menuEstaAbierto, () => {
+  actualizaAtributoTabIndex(menuEstaAbierto.value)
 })
 </script>

--- a/src/componentes/navegacion-principal/SisdaiNavegacionPrincipal.vue
+++ b/src/componentes/navegacion-principal/SisdaiNavegacionPrincipal.vue
@@ -1,3 +1,73 @@
+<script setup>
+import { defineProps, onMounted, ref, watch } from 'vue'
+import { useMenuDesenfocable } from '../../composables/useMenuDesenfocable'
+
+defineProps({
+  navInformacion: {
+    default: '',
+    type: String,
+  },
+  fija: {
+    default: true,
+    type: Boolean,
+  },
+})
+
+//Que el menu se pueda cerrar automaticamente al enfocar otra cosa
+const cuadroElementosMenu = ref(null)
+const {
+  menuEstaAbierto,
+  alternarMenu,
+  // eslint-disable-next-line
+  alternarSubmenu,
+} = useMenuDesenfocable(cuadroElementosMenu)
+
+const navMenuConahcyt =
+  document.getElementsByClassName('nav-menu')[1]['children']
+
+/**
+ * Agrega el atributo tabindex a los elementos de lista,
+ * si está en versión móvil
+ */
+function agregaAtributoTabIndex() {
+  if (window.innerWidth < 768) {
+    for (let index = 0; index < navMenuConahcyt.length; index++) {
+      const elemento = navMenuConahcyt[index]['children'][0]
+      elemento.tabIndex = '-1'
+    }
+  }
+}
+
+/**
+ * Si el menú está abierto en móvil, remueve el atributo tabIndex.
+ * Si está cerrado, agrega el atributo tabIndex en -1 para
+ * saltarse los enlaces con el teclado secuencial.
+ */
+function actualizaAtributoTabIndex(estaAbierto) {
+  if (window.innerWidth < 768) {
+    if (estaAbierto) {
+      for (let i = 0; i < navMenuConahcyt.length; i++) {
+        const elemento = navMenuConahcyt[i]['children'][0]
+        elemento.removeAttribute('tabIndex')
+      }
+    } else {
+      for (let j = 0; j < navMenuConahcyt.length; j++) {
+        const elemento = navMenuConahcyt[j]['children'][0]
+        elemento.tabIndex = '-1'
+      }
+    }
+  }
+}
+
+onMounted(() => {
+  agregaAtributoTabIndex()
+})
+
+watch(menuEstaAbierto, () => {
+  actualizaAtributoTabIndex(menuEstaAbierto.value)
+})
+</script>
+
 <template>
   <nav
     class="navegacion navegacion-conacyt"
@@ -70,72 +140,3 @@
     </div>
   </nav>
 </template>
-
-<script setup>
-import { defineProps, onMounted, ref, watch } from 'vue'
-import { useMenuDesenfocable } from '../../composables/useMenuDesenfocable'
-
-defineProps({
-  navInformacion: {
-    default: '',
-    type: String,
-  },
-  fija: {
-    default: true,
-    type: Boolean,
-  },
-})
-
-//Que el menu se pueda cerrar automaticamente al enfocar otra cosa
-const cuadroElementosMenu = ref(null)
-const {
-  menuEstaAbierto,
-  alternarMenu,
-  // eslint-disable-next-line
-  alternarSubmenu,
-} = useMenuDesenfocable(cuadroElementosMenu)
-
-const navMenu = document.getElementsByClassName('nav-menu')
-
-/**
- * Agrega el atributo tabindex a los elementos de lista,
- * si está en versión móvil
- */
-function agregaAtributoTabIndex() {
-  if (window.innerWidth < 768) {
-    for (let index = 0; index < navMenu[1]['children'].length; index++) {
-      const element = navMenu[1]['children'][index]['children'][0]
-      element.tabIndex = '-1'
-    }
-  }
-}
-
-/**
- * Si el menú está abierto en móvil, remueve el atributo tabIndex.
- * Si está cerrado, agrega el atributo tabIndex en -1 para
- * saltarse los enlaces con el teclado secuencial.
- */
-function actualizaAtributoTabIndex(estaAbierto) {
-  if (window.innerWidth < 768) {
-    if (estaAbierto) {
-      for (let i = 0; i < navMenu[1]['children'].length; i++) {
-        const element = navMenu[1]['children'][i]['children'][0]
-        element.removeAttribute('tabIndex')
-      }
-    } else {
-      for (let j = 0; j < navMenu[1]['children'].length; j++) {
-        const element = navMenu[1]['children'][j]['children'][0]
-        element.tabIndex = '-1'
-      }
-    }
-  }
-}
-
-onMounted(() => {
-  agregaAtributoTabIndex()
-})
-
-watch(menuEstaAbierto, () => {
-  actualizaAtributoTabIndex(menuEstaAbierto.value)
-})
-</script>

--- a/src/componentes/navegacion-principal/SisdaiNavegacionPrincipal.vue
+++ b/src/componentes/navegacion-principal/SisdaiNavegacionPrincipal.vue
@@ -22,8 +22,7 @@ const {
   alternarSubmenu,
 } = useMenuDesenfocable(cuadroElementosMenu)
 
-const navMenuConahcyt =
-  document.getElementsByClassName('nav-menu')[1]['children']
+const navMenuConahcyt = ref({})
 
 /**
  * Agrega el atributo tabindex a los elementos de lista,
@@ -31,8 +30,8 @@ const navMenuConahcyt =
  */
 function agregaAtributoTabIndex() {
   if (window.innerWidth < 768) {
-    for (let index = 0; index < navMenuConahcyt.length; index++) {
-      const elemento = navMenuConahcyt[index]['children'][0]
+    for (let index = 0; index < navMenuConahcyt.value.length; index++) {
+      const elemento = navMenuConahcyt.value[index]['children'][0]
       elemento.tabIndex = '-1'
     }
   }
@@ -46,13 +45,13 @@ function agregaAtributoTabIndex() {
 function actualizaAtributoTabIndex(estaAbierto) {
   if (window.innerWidth < 768) {
     if (estaAbierto) {
-      for (let i = 0; i < navMenuConahcyt.length; i++) {
-        const elemento = navMenuConahcyt[i]['children'][0]
+      for (let i = 0; i < navMenuConahcyt.value.length; i++) {
+        const elemento = navMenuConahcyt.value[i]['children'][0]
         elemento.removeAttribute('tabIndex')
       }
     } else {
-      for (let j = 0; j < navMenuConahcyt.length; j++) {
-        const elemento = navMenuConahcyt[j]['children'][0]
+      for (let j = 0; j < navMenuConahcyt.value.length; j++) {
+        const elemento = navMenuConahcyt.value[j]['children'][0]
         elemento.tabIndex = '-1'
       }
     }
@@ -60,6 +59,8 @@ function actualizaAtributoTabIndex(estaAbierto) {
 }
 
 onMounted(() => {
+  navMenuConahcyt.value =
+    document.getElementsByClassName('nav-menu')[1]['children']
   agregaAtributoTabIndex()
 })
 

--- a/src/componentes/navegacion-principal/SisdaiNavegacionPrincipal.vue
+++ b/src/componentes/navegacion-principal/SisdaiNavegacionPrincipal.vue
@@ -1,28 +1,3 @@
-<script setup>
-import { defineProps, ref } from 'vue'
-import { useMenuDesenfocable } from '../../composables/useMenuDesenfocable'
-
-defineProps({
-  navInformacion: {
-    default: '',
-    type: String,
-  },
-  fija: {
-    default: true,
-    type: Boolean,
-  },
-})
-
-//Que el menu se pueda cerrar automaticamente al enfocar otra cosa
-const cuadroElementosMenu = ref(null)
-const {
-  menuEstaAbierto,
-  alternarMenu,
-  // eslint-disable-next-line
-  alternarSubmenu,
-} = useMenuDesenfocable(cuadroElementosMenu)
-</script>
-
 <template>
   <nav
     class="navegacion navegacion-conacyt"
@@ -95,3 +70,72 @@ const {
     </div>
   </nav>
 </template>
+
+<script setup>
+import { defineProps, onMounted, ref, watch } from 'vue'
+import { useMenuDesenfocable } from '../../composables/useMenuDesenfocable'
+
+defineProps({
+  navInformacion: {
+    default: '',
+    type: String,
+  },
+  fija: {
+    default: true,
+    type: Boolean,
+  },
+})
+
+//Que el menu se pueda cerrar automaticamente al enfocar otra cosa
+const cuadroElementosMenu = ref(null)
+const {
+  menuEstaAbierto,
+  alternarMenu,
+  // eslint-disable-next-line
+  alternarSubmenu,
+} = useMenuDesenfocable(cuadroElementosMenu)
+
+const navMenu = document.getElementsByClassName('nav-menu')
+
+/**
+ * Agrega el atributo tabindex a los elementos de lista,
+ * si está en versión móvil
+ */
+function agregaAtributoTabIndex() {
+  if (window.innerWidth < 768) {
+    for (let index = 0; index < navMenu[1]['children'].length; index++) {
+      const element = navMenu[1]['children'][index]['children'][0]
+      element.tabIndex = '-1'
+    }
+  }
+}
+
+/**
+ * Si el menú está abierto en móvil, remueve el atributo tabIndex.
+ * Si está cerrado, agrega el atributo tabIndex en -1 para
+ * saltarse los enlaces con el teclado secuencial.
+ */
+function actualizaAtributoTabIndex(estaAbierto) {
+  if (window.innerWidth < 768) {
+    if (estaAbierto) {
+      for (let i = 0; i < navMenu[1]['children'].length; i++) {
+        const element = navMenu[1]['children'][i]['children'][0]
+        element.removeAttribute('tabIndex')
+      }
+    } else {
+      for (let j = 0; j < navMenu[1]['children'].length; j++) {
+        const element = navMenu[1]['children'][j]['children'][0]
+        element.tabIndex = '-1'
+      }
+    }
+  }
+}
+
+onMounted(() => {
+  agregaAtributoTabIndex()
+})
+
+watch(menuEstaAbierto, () => {
+  actualizaAtributoTabIndex(menuEstaAbierto.value)
+})
+</script>


### PR DESCRIPTION
- Se agrega regla para condicionar el atributo tabIndex en elementos contraídos o menús de navegación que se cierran y se abren como: menú de accesibilidad, menú lateral, barra de navegación de gobmx, barra de navegación principal de conahcyt y la navegación colapsable. Con la finalidad de permitir y limitar la navegación por teclado secuencial por temas de accesibilidad.

Lo que se hizo fue estar observando si estos están abiertos o cerrados para dinámicamente agregar el atributo a los elementos de lista anidados en los menús.

https://project.crip.conacyt.mx/project/macrocelula/task/2701
